### PR TITLE
Use vitest describe imports in data provider tests

### DIFF
--- a/tests/unit-tests/data-providers/graphql.test.ts
+++ b/tests/unit-tests/data-providers/graphql.test.ts
@@ -1,5 +1,4 @@
-import { describe } from 'node:test';
-import { expect, test, vi } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 
 import {
     GET_POST,

--- a/tests/unit-tests/data-providers/rest-api.test.ts
+++ b/tests/unit-tests/data-providers/rest-api.test.ts
@@ -1,5 +1,4 @@
-import { describe } from 'node:test';
-import { Mock, expect, test, vi } from 'vitest';
+import { describe, Mock, expect, test, vi } from 'vitest';
 
 import { POST_PAGE_SIZE } from '../../../app/constants';
 import { Post, PostsAPIResponse } from '../../../app/lib/definitions';


### PR DESCRIPTION
## Summary
- replace node:test describe imports with vitest to avoid bundling built-in modules in Vite
- ensure unit tests rely on consistent Vitest APIs

## Testing
- pnpm test -- --runInBand


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937ce2439a48332931e93bc67fd3254)