### PR TITLE
Fix blog title link to navigate to /blog on blog pages

### DIFF
--- a/app/components/blog-header.tsx
+++ b/app/components/blog-header.tsx
@@ -4,7 +4,7 @@ import Search from './posts/post-search';
 export default function BlogHeader() {
     return (
         <header className="flex flex-col justify-between sm:flex-row sm:justify-between p-4">
-            <PageTitle />
+            <PageTitle href="/blog" />
             <Search placeholder="Search in posts..." />
         </header>
     );

--- a/app/components/page-title.tsx
+++ b/app/components/page-title.tsx
@@ -1,10 +1,16 @@
 import Link from 'next/link';
 
-export default function PageTitle() {
+type PageTitleProps = {
+    href?: string;
+};
+
+export default function PageTitle({ href }: PageTitleProps) {
     const rootURL = process.env.NEXT_PUBLIC_ROOT_URL ?? '';
+    const titleHref = href ?? rootURL;
+
     return (
         <h1 className="text-3xl font-bold rainbow-text text-center sm:text-left content-center">
-            <Link href={rootURL}>abelcastro.dev</Link>
+            <Link href={titleHref}>abelcastro.dev</Link>
         </h1>
     );
 }


### PR DESCRIPTION
### Motivation
- The blog header title previously linked to the site root (`NEXT_PUBLIC_ROOT_URL`) which caused clicks on the blog page title to navigate away from `/blog` to the site root. 
- The intent is to have the title on blog pages keep the user within the blog section by navigating to `/blog`.

### Description
- Add an optional `href` prop to `PageTitle` and use it when provided while preserving the existing fallback to `NEXT_PUBLIC_ROOT_URL` (`app/components/page-title.tsx`).
- Update `BlogHeader` to pass `href="/blog"` to `PageTitle` so the title link points to `/blog` on blog pages (`app/components/blog-header.tsx`).

### Testing
- Ran the page unit tests with `npm test -- tests/unit-tests/pages.test.tsx` and the suite completed successfully. 
- Vitest reported the test file ran and the tests passed (1 file passed, 5 tests passed, 2 skipped).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de3f73cf8c8332b8394abe15b76693)