### PR TITLE
Prevent tag overflow on small screens with expandable tag list

### DIFF
--- a/app/components/posts/post-tags.tsx
+++ b/app/components/posts/post-tags.tsx
@@ -1,16 +1,46 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
 import { Tag } from '../../lib/definitions';
 
+const VISIBLE_TAGS_COUNT = 3;
+
 export default function PostTags({ tags }: { tags: Tag[] }) {
+    const [isExpanded, setIsExpanded] = useState(false);
+
+    const hasHiddenTags = tags.length > VISIBLE_TAGS_COUNT;
+    const hiddenTagsCount = Math.max(tags.length - VISIBLE_TAGS_COUNT, 0);
+
+    const displayedTags = useMemo(() => {
+        if (isExpanded || !hasHiddenTags) {
+            return tags;
+        }
+
+        return tags.slice(0, VISIBLE_TAGS_COUNT);
+    }, [hasHiddenTags, isExpanded, tags]);
+
     return (
-        <div className="flex space-x-2 mb-2">
-            {tags.map((tag, index) => (
+        <div className="mb-2 flex max-w-full flex-wrap gap-2">
+            {displayedTags.map((tag, index) => (
                 <span
                     key={`tag-${index}`}
-                    className="text-xs bg-sky-100 text-gray-800 py-1 px-2 rounded"
+                    className="max-w-full break-words rounded bg-sky-100 px-2 py-1 text-xs text-gray-800"
                 >
                     {tag.name}
                 </span>
             ))}
+
+            {hasHiddenTags && !isExpanded && (
+                <button
+                    aria-label="Show all tags"
+                    className="rounded bg-sky-100 px-2 py-1 text-xs text-gray-800"
+                    onClick={() => setIsExpanded(true)}
+                    type="button"
+                >
+                    + {hiddenTagsCount}
+                </button>
+            )}
         </div>
     );
 }

--- a/tests/unit-tests/components/post-tags.test.tsx
+++ b/tests/unit-tests/components/post-tags.test.tsx
@@ -1,0 +1,35 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+
+import PostTags from '../../../app/components/posts/post-tags';
+
+const tags = [
+    { name: 'spec-driven-development' },
+    { name: 'monorepo' },
+    { name: 'microservices' },
+    { name: 'architecture' },
+    { name: 'ai-first-development' },
+];
+
+describe('PostTags', () => {
+    test('shows only three tags and a +N button by default', () => {
+        render(<PostTags tags={tags} />);
+
+        expect(screen.getByText('spec-driven-development')).toBeInTheDocument();
+        expect(screen.getByText('monorepo')).toBeInTheDocument();
+        expect(screen.getByText('microservices')).toBeInTheDocument();
+        expect(screen.queryByText('architecture')).not.toBeInTheDocument();
+        expect(screen.queryByText('ai-first-development')).not.toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Show all tags' })).toHaveTextContent('+ 2');
+    });
+
+    test('expands and shows all tags when +N is clicked', () => {
+        render(<PostTags tags={tags} />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Show all tags' }));
+
+        expect(screen.getByText('architecture')).toBeInTheDocument();
+        expect(screen.getByText('ai-first-development')).toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Show all tags' })).not.toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
### Motivation
- Long or many tags overflow the viewport on small screens, so the tags UI must avoid exceeding the container width and provide an accessible way to view all tags.

### Description
- Convert `app/components/posts/post-tags.tsx` to a client component that shows at most 3 tags by default and adds a `+ N` button to reveal the remaining tags using `useState`/`useMemo`.
- Ensure the tags container wraps and keeps chips within the viewport by adding Tailwind utilities such as `max-w-full`, `flex-wrap`, `gap-2`, and `break-words` to the tag elements.
- Add tests at `tests/unit-tests/components/post-tags.test.tsx` validating the collapsed state (3 tags + `+ N`) and the expanded state (all tags visible after clicking the expander).

### Testing
- Ran `npm run test -- tests/unit-tests/components/post-tags.test.tsx` and the unit suite passed (2 tests).
- Ran `npm run lint` which failed in this environment due to the project lint configuration referencing an invalid directory.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb0fd945e88332a50a8cb8e5c2c6ff)