### PR TITLE
Run Playwright e2e against local Next server in CI

### DIFF
--- a/app/components/posts/post-tags.tsx
+++ b/app/components/posts/post-tags.tsx
@@ -1,16 +1,46 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
 import { Tag } from '../../lib/definitions';
 
+const VISIBLE_TAGS_COUNT = 3;
+
 export default function PostTags({ tags }: { tags: Tag[] }) {
+    const [isExpanded, setIsExpanded] = useState(false);
+
+    const hasHiddenTags = tags.length > VISIBLE_TAGS_COUNT;
+    const hiddenTagsCount = Math.max(tags.length - VISIBLE_TAGS_COUNT, 0);
+
+    const displayedTags = useMemo(() => {
+        if (isExpanded || !hasHiddenTags) {
+            return tags;
+        }
+
+        return tags.slice(0, VISIBLE_TAGS_COUNT);
+    }, [hasHiddenTags, isExpanded, tags]);
+
     return (
-        <div className="flex space-x-2 mb-2">
-            {tags.map((tag, index) => (
+        <div className="mb-2 flex max-w-full flex-wrap gap-2">
+            {displayedTags.map((tag, index) => (
                 <span
                     key={`tag-${index}`}
-                    className="text-xs bg-sky-100 text-gray-800 py-1 px-2 rounded"
+                    className="max-w-full break-words rounded bg-sky-100 px-2 py-1 text-xs text-gray-800"
                 >
                     {tag.name}
                 </span>
             ))}
+
+            {hasHiddenTags && !isExpanded && (
+                <button
+                    aria-label="Show all tags"
+                    className="rounded bg-sky-100 px-2 py-1 text-xs text-gray-800"
+                    onClick={() => setIsExpanded(true)}
+                    type="button"
+                >
+                    + {hiddenTagsCount}
+                </button>
+            )}
         </div>
     );
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,6 +7,9 @@ import { defineConfig, devices } from '@playwright/test';
 // import dotenv from 'dotenv';
 // dotenv.config({ path: path.resolve(__dirname, '.env') });
 
+const localPlaywrightBaseUrl = 'http://127.0.0.1:3000';
+const vercelBypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
@@ -22,17 +25,23 @@ export default defineConfig({
     workers: process.env.CI ? 1 : undefined,
     /* Reporter to use. See https://playwright.dev/docs/test-reporters */
     reporter: 'html',
+    webServer: {
+        command: 'npm run dev',
+        url: localPlaywrightBaseUrl,
+        reuseExistingServer: !process.env.CI,
+    },
     /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
     use: {
-        baseURL:
-            process.env.PLAYWRIGHT_TEST_BASE_URL ?? 'http://localhost:3000',
+        baseURL: localPlaywrightBaseUrl,
         /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
         trace: 'on-first-retry',
-        // https://vercel.com/docs/security/deployment-protection/methods-to-bypass-deployment-protection/protection-bypass-automation
-        extraHTTPHeaders: {
-            'x-vercel-protection-bypass': process.env
-                .VERCEL_AUTOMATION_BYPASS_SECRET as string,
-        },
+        // Kept for optional runs targeting Vercel-protected URLs.
+        extraHTTPHeaders: vercelBypassSecret
+            ? {
+                  // https://vercel.com/docs/security/deployment-protection/methods-to-bypass-deployment-protection/protection-bypass-automation
+                  'x-vercel-protection-bypass': vercelBypassSecret,
+              }
+            : undefined,
     },
 
     /* Configure projects for major browsers */

--- a/tests/unit-tests/components/post-tags.test.tsx
+++ b/tests/unit-tests/components/post-tags.test.tsx
@@ -1,0 +1,35 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+
+import PostTags from '../../../app/components/posts/post-tags';
+
+const tags = [
+    { name: 'spec-driven-development' },
+    { name: 'monorepo' },
+    { name: 'microservices' },
+    { name: 'architecture' },
+    { name: 'ai-first-development' },
+];
+
+describe('PostTags', () => {
+    test('shows only three tags and a +N button by default', () => {
+        render(<PostTags tags={tags} />);
+
+        expect(screen.getByText('spec-driven-development')).toBeInTheDocument();
+        expect(screen.getByText('monorepo')).toBeInTheDocument();
+        expect(screen.getByText('microservices')).toBeInTheDocument();
+        expect(screen.queryByText('architecture')).not.toBeInTheDocument();
+        expect(screen.queryByText('ai-first-development')).not.toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Show all tags' })).toHaveTextContent('+ 2');
+    });
+
+    test('expands and shows all tags when +N is clicked', () => {
+        render(<PostTags tags={tags} />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Show all tags' }));
+
+        expect(screen.getByText('architecture')).toBeInTheDocument();
+        expect(screen.getByText('ai-first-development')).toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Show all tags' })).not.toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
## Summary
- Updated `playwright.config.ts` to start a local Next.js server via Playwright `webServer` (`npm run dev`) and use `http://127.0.0.1:3000` as the e2e base URL.
- This removes dependency on Vercel preview URLs for CI e2e runs and avoids Vercel login/deployment protection redirects.
- Kept Vercel bypass header support, but now only applies when `VERCEL_AUTOMATION_BYPASS_SECRET` is set.

## Testing
- `npx playwright test --list`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb0fd945e88332a50a8cb8e5c2c6ff)