### PR TITLE
Fix GitHub Actions install step for pnpm 11

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -9,12 +9,12 @@ jobs:
         container:
             image: mcr.microsoft.com/playwright:v1.46.0-jammy
         steps:
-            - uses: actions/checkout@v3
-            - uses: actions/setup-node@v3
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
               with:
-                  node-version: 20.x
+                  node-version: 24.x
             - name: Install dependencies
-              run: npm install -g pnpm && pnpm install
+              run: corepack enable && pnpm install --frozen-lockfile
             - name: Install Playwright Browsers
               run: pnpm exec playwright install --with-deps
             - name: Run Playwright tests

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,17 +12,17 @@ jobs:
 
         strategy:
             matrix:
-                node-version: [20]
+                node-version: [24]
 
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
 
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: ${{ matrix.node-version }}
             - name: Install dependencies
-              run: npm install -g pnpm && pnpm install
+              run: corepack enable && pnpm install --frozen-lockfile
             - run: pnpm test:coverage
 
             - name: Upload coverage reports to Codecov


### PR DESCRIPTION
### Motivation

- The CI install step was failing because the workflows used Node.js 20 and globally installed `pnpm`, while the repo requires Node 24 and `pnpm@11.x` which needs newer Node and Corepack-managed installs.

### Description

- Updated `.github/workflows/e2e-tests.yml` to use `actions/checkout@v4`, `actions/setup-node@v4`, and `node-version: 24.x`.
- Updated `.github/workflows/unit-tests.yml` to use `actions/checkout@v4`, `actions/setup-node@v4`, and `node-version: [24]` in the matrix.
- Replaced `npm install -g pnpm && pnpm install` with `corepack enable && pnpm install --frozen-lockfile` to rely on Corepack and the `packageManager`-pinned `pnpm`.

### Testing

- Ran `git diff --check` to ensure no whitespace or patch issues, which succeeded.
- Ran a Python assertion script that checks each workflow contains the expected `node-version` marker and `corepack enable && pnpm install --frozen-lockfile`, and that `npm install -g pnpm` is absent; the final adjusted script passed.
- Verified the workflows show the updated install commands and Node versions via automated file checks, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a549e79531c83328a39023b6ba0d087)