### PR TITLE
Fix pnpm setup in unit test workflow

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -17,6 +17,11 @@ jobs:
         steps:
             - uses: actions/checkout@v4
 
+            - name: Enable pnpm
+              uses: pnpm/action-setup@v4
+              with:
+                  run_install: false
+
             - name: Use Node.js ${{ matrix.node-version }}
               uses: actions/setup-node@v4
               with:
@@ -24,7 +29,7 @@ jobs:
                   cache: pnpm
 
             - name: Install dependencies
-              run: corepack enable && pnpm install --frozen-lockfile
+              run: pnpm install --frozen-lockfile
 
             - run: pnpm test:coverage
 


### PR DESCRIPTION
### Motivation
- Ensure `pnpm` is available before `actions/setup-node` configures `cache: pnpm` so dependency installation and caching work reliably on Node 24 runners.

### Description
- Add `pnpm/action-setup@v4` with `run_install: false` before `actions/setup-node@v4` and remove the inline `corepack enable`, leaving the install step as `pnpm install --frozen-lockfile`.

### Testing
- Ran `git diff --check` which passed, and attempted `nvm use 24 && pnpm --version && pnpm test:coverage` but the install step failed due to npm registry fetch errors so the test run could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54a5f7610483328bb664bacf55d853)